### PR TITLE
経理部の固定資産_数量分金額を分割する処理を追加

### DIFF
--- a/koteisisan/quantity.ts
+++ b/koteisisan/quantity.ts
@@ -12,7 +12,10 @@ function main(workbook: ExcelScript.Workbook) {
   // ヘッダー取得（1行目）
   const header = sheet.getRange("A1:AP1").getValues()[0];
 
-  const quantityColIndex = 16; // 「数量」列（Q列）←★修正箇所
+  const quantityColIndex = 16; // 「数量」列（Q列）
+  const priceExclTaxColIndex = 8;  // I列: 購入額合価(税抜)
+  const taxColIndex = 9;           // J列: 消費税
+  const priceInclTaxColIndex = 10; // K列: 購入額合価(税込)
 
   let expandedData: (string | number | boolean | null)[][] = [];
 
@@ -25,9 +28,31 @@ function main(workbook: ExcelScript.Workbook) {
     const quantity = Number(row[quantityColIndex]);
     if (isNaN(quantity) || quantity < 1) continue;
 
+    // 金額（整数）を利用
+    const totalExclTax = Number(row[priceExclTaxColIndex]) || 0;
+    const totalTax = Number(row[taxColIndex]) || 0;
+    const totalInclTax = Number(row[priceInclTaxColIndex]) || 0;
+
+    // 均等に割り切る金額
+    const baseExclTax = Math.floor(totalExclTax / quantity);
+    const baseTax = Math.floor(totalTax / quantity);
+    const baseInclTax = Math.floor(totalInclTax / quantity);
+
+    // ++ 差分（最後の1件に加算）
+    const remainderExclTax = totalExclTax - baseExclTax * quantity;
+    const remainderTax = totalTax - baseTax * quantity;
+    const remainderInclTax = totalInclTax - baseInclTax * quantity;
+
     for (let i = 1; i <= quantity; i++) {
       let newRow = [...row];
-      newRow[quantityColIndex] = i; // 「数量」列を1〜Nの連番に
+      newRow[quantityColIndex] = 1; // 数量列は常に「1」に固定している
+
+      // 金額列に分割値を設定（最後の1つに端数調整分を加算）
+      const isLast = i === quantity;
+      newRow[priceExclTaxColIndex] = baseExclTax + (isLast ? remainderExclTax : 0);
+      newRow[taxColIndex] = baseTax + (isLast ? remainderTax : 0);
+      newRow[priceInclTaxColIndex] = baseInclTax + (isLast ? remainderInclTax : 0);
+
       expandedData.push(newRow);
     }
   }

--- a/koteisisan/quantity.ts
+++ b/koteisisan/quantity.ts
@@ -2,7 +2,7 @@ function main(workbook: ExcelScript.Workbook) {
   const sheet = workbook.getWorksheet("資産分類区分、利用部門、管理部門をマスタの番号に変換");
 
 
-  // 明示的に A2 から AP列まで（最大1000行）を取得
+  // A2 から AP列まで（最大1000行）を取得
   const maxRows = 1000;
   const numCols = 42;
   const dataStartRow = 1; // A2 から開始（0-indexedで1）
@@ -12,7 +12,7 @@ function main(workbook: ExcelScript.Workbook) {
   // ヘッダー取得（1行目）
   const header = sheet.getRange("A1:AP1").getValues()[0];
 
-  const quantityColIndex = 16; // 「数量」列（Q列）
+  const quantityColIndex = 16; // Q列:「数量」列
   const priceExclTaxColIndex = 8;  // I列: 購入額合価(税抜)
   const taxColIndex = 9;           // J列: 消費税
   const priceInclTaxColIndex = 10; // K列: 購入額合価(税込)
@@ -28,30 +28,30 @@ function main(workbook: ExcelScript.Workbook) {
     const quantity = Number(row[quantityColIndex]);
     if (isNaN(quantity) || quantity < 1) continue;
 
-    // 金額（整数）を利用
+    // 金額（整数）を取得
     const totalExclTax = Number(row[priceExclTaxColIndex]) || 0;
     const totalTax = Number(row[taxColIndex]) || 0;
     const totalInclTax = Number(row[priceInclTaxColIndex]) || 0;
 
-    // 均等に割り切る金額
+    // 金額を数量で割る。Math.floorで小数点なし。小数点以下切り捨て。(1円以下)
     const baseExclTax = Math.floor(totalExclTax / quantity);
     const baseTax = Math.floor(totalTax / quantity);
     const baseInclTax = Math.floor(totalInclTax / quantity);
 
-    // ++ 差分（最後の1件に加算）
-    const remainderExclTax = totalExclTax - baseExclTax * quantity;
-    const remainderTax = totalTax - baseTax * quantity;
-    const remainderInclTax = totalInclTax - baseInclTax * quantity;
+    // 総額から数量-1の金額を引く。
+    const remainderExclTax = totalExclTax - baseExclTax * (quantity - 1);
+    const remainderTax = totalTax - baseTax * (quantity - 1);
+    const remainderInclTax = totalInclTax - baseInclTax * (quantity - 1);
 
     for (let i = 1; i <= quantity; i++) {
       let newRow = [...row];
-      newRow[quantityColIndex] = 1; // 数量列は常に「1」に固定している
+      newRow[quantityColIndex] = 1; // 数量列は常に「1」に固定
 
-      // 金額列に分割値を設定（最後の1つに端数調整分を加算）
       const isLast = i === quantity;
-      newRow[priceExclTaxColIndex] = baseExclTax + (isLast ? remainderExclTax : 0);
-      newRow[taxColIndex] = baseTax + (isLast ? remainderTax : 0);
-      newRow[priceInclTaxColIndex] = baseInclTax + (isLast ? remainderInclTax : 0);
+      //最後の1件に誤差を加算することで、金額の合計が元と一致するように調整する
+      newRow[priceExclTaxColIndex] = isLast ? remainderExclTax : baseExclTax;
+      newRow[taxColIndex] = isLast ? remainderTax : baseTax;
+      newRow[priceInclTaxColIndex] = isLast ? remainderInclTax : baseInclTax;
 
       expandedData.push(newRow);
     }


### PR DESCRIPTION
## 経理部からのご依頼の対応

追加内容
- 数量分ループ処理をさせるが、数量は1に固定し投入する。
- すべての金額を数量分分割させる。→　金額/数量
- 20台の場合、20台の金額は1から19台目の金額を差し引いた値を設定する。
